### PR TITLE
Enabled/Disable direct post into home page

### DIFF
--- a/bp-core/admin/bp-core-admin-functions.php
+++ b/bp-core/admin/bp-core-admin-functions.php
@@ -435,7 +435,6 @@ function bp_core_get_admin_tabs( $active_tab = '' ) {
 
     if (!is_xtecadmin()) {
         unset($tabs[1]); // Pages tab
-        unset($tabs[2]); // Settings tab
     }
 
 //************ FI

--- a/bp-core/admin/bp-core-admin-settings.php
+++ b/bp-core/admin/bp-core-admin-settings.php
@@ -312,13 +312,25 @@ function bp_core_admin_settings_save() {
 		if ( isset( $wp_settings_fields['buddypress'] ) ) {
 			foreach( (array) $wp_settings_fields['buddypress'] as $section => $settings ) {
 				foreach( $settings as $setting_name => $setting ) {
+					//XTEC ************ AFEGIT ­Only xtecadmin user can change values to differents options. Admin user only can change directo post into home page
+ 					//2016.06.20 @xaviernietosanchez
+					if( is_xtecadmin() || $setting_name == 'bp-plugin-enabled-post-home' ){
+					//************ FI
 					$value = isset( $_POST[$setting_name] ) ? $_POST[$setting_name] : '';
 
 					bp_update_option( $setting_name, $value );
+					//XTEC ************ AFEGIT ­Only xtecadmin user can change values to differents options. Admin user only can change directo post into home page
+					//2016.06.20 @xaviernietosanchez
+					}
+					//************ FI
 				}
 			}
 		}
 
+		//XTEC ************ AFEGIT ­Only xtecadmin user can change values to differents options.
+		//2016.06.20 @xaviernietosanchez
+		if( is_xtecadmin() ){
+		//************ FI
 		// Some legacy options are not registered with the Settings API, or are reversed in the UI.
 		$legacy_options = array(
 			'bp-disable-account-deletion',
@@ -341,6 +353,10 @@ function bp_core_admin_settings_save() {
 		}
 
 		bp_core_redirect( add_query_arg( array( 'page' => 'bp-settings', 'updated' => 'true' ), bp_get_admin_url( 'admin.php' ) ) );
+		//XTEC ************ AFEGIT ­Only xtecadmin user can change values to differents options.
+		//2016.06.20 @xaviernietosanchez
+		}
+		//************ FI
 	}
 }
 add_action( 'bp_admin_init', 'bp_core_admin_settings_save', 100 );

--- a/bp-core/classes/class-bp-admin.php
+++ b/bp-core/classes/class-bp-admin.php
@@ -381,6 +381,11 @@ class BP_Admin {
 	public function register_admin_settings() {
 
 		/* Main Section ******************************************************/
+		
+		//XTEC ************ AFEGIT ­Hidden setting options to all users except to xtecadmin
+		//2016.06.21 @xaviernietosanchez ­ reference
+		if( is_xtecadmin() ){
+		//************ FI
 
 		// Add the main section.
 		add_settings_section( 'bp_main', __( 'Main Settings', 'buddypress' ), 'bp_admin_setting_callback_main_section', 'buddypress' );
@@ -476,6 +481,12 @@ class BP_Admin {
 				register_setting( 'buddypress', '_bp_enable_akismet', 'intval' );
 			}
 		}
+
+		//XTEC ************ AFEGIT ­Hidden setting options to all users except to xtecadmin
+		//2016.06.21 @xaviernietosanchez ­ reference
+  		}
+		//************ FI
+
 	}
 
 	/**

--- a/bp-templates/bp-legacy/buddypress/activity/index.php
+++ b/bp-templates/bp-legacy/buddypress/activity/index.php
@@ -26,9 +26,19 @@ do_action( 'bp_before_directory_activity' ); ?>
 	 */
 	do_action( 'bp_before_directory_activity_content' ); ?>
 
-	<?php if ( is_user_logged_in() ) : ?>
-
-		<?php bp_get_template_part( 'activity/post-form' ); ?>
+	<?php
+	//XTEC ************ MODIFICAT ­ Check if allow post into home page
+	//2016.06.16 @xaviernietosanchez
+	?>
+	­­­<?php if ( is_user_logged_in() && bp_get_option( 'bp-plugin-enabled-post-home' ) ) : ?>
+	<?php
+	//************ ORIGINAL
+	/*
+	­­­<?php if ( is_user_logged_in() ) : ?>
+	*/
+	//************ FI
+	?>
+			<?php bp_get_template_part( 'activity/post-form' ); ?>
 
 	<?php endif; ?>
 


### PR DESCRIPTION
Permetre la opció de deshabilitar l'escriptura directa al node general.
- S'ha afegit una opció com a configuració.
- Modificació i adaptació del submenú del buddypress segons especificacions de Xavi.
- Ocultar paràmetres de configuració pels usuaris "admins", que si poden veure els usuaris "xtecadmins".

Per realitzar les proves cal entrar como a usuari admin, anar al menú de buddypress i clicar sobre configuració al submenú lateral dret, o a configuració a la primera columna del body. Marcar/desmarcar el input i observar en un node general que apareix/desapareix la capsa per poder escriure.

Fer el mateix procediment amb un usuari xtecadmin però observant que tots els parametres que visualitza de mes l'xtecadmin, es mantenen intactes.
